### PR TITLE
0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+<a name="unreleased"></a>
+## [Unreleased]
+
+
+<a name="0.1.0"></a>
+## 0.1.0 - 2020-07-09
+### Chore
+- bump circleci node version to 12
+- **init:** setup bare repo with framework for packaging
+
+### Features
+- Initial build of header injection
+- **good:** add stream transform for Good ([#1](https://github.com/GoodwayGroup/lib-hapi-trace-headers/issues/1))
+- **specs:** added tests and :100: coverage
+
+### Tech Debt
+- **coverage:** add coveralls
+
+
+[Unreleased]: https://github.com/GoodwayGroup/lib-hapi-trace-headers/compare/0.1.0...HEAD

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodwaygroup/lib-hapi-good-tracer",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodwaygroup/lib-hapi-good-tracer",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Hapi plugin for injecting tracer info into response headers and logs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## 0.1.0 - 2020-07-09
### Chore
- bump circleci node version to 12
- **init:** setup bare repo with framework for packaging

### Features
- Initial build of header injection
- **good:** add stream transform for Good ([#1](https://github.com/GoodwayGroup/lib-hapi-trace-headers/issues/1))
- **specs:** added tests and :100: coverage

### Tech Debt
- **coverage:** add coveralls