### PR TITLE
fix(cache): silence and log cache set errors to avoid nuking a requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ If an object is stale for the length of the TTL, it will be culled.
 
 There is a max number of keys that can be active at any time to help with memory concerns.
 
+The `postResponseCleanup` option is on by default. This will delete the cached data associated with the request on a delay (default of `1000 ms`).  
+
 See [node-cache](https://github.com/node-cache/node-cache) for available settings.
 
 ## Configuration Options
@@ -159,6 +161,8 @@ See [node-cache](https://github.com/node-cache/node-cache) for available setting
 - `enableStatsRoute`: defaults to `false`. Publish a route to `/good-tracer/stats` that exposes the current metrics for [`node-cache` statistics](https://github.com/node-cache/node-cache#statistics-stats).
 - `baseRoute`: defaults to `''`. Prepends to the `/good-tracer/stats` route.
     - Example: `baseRoute = /serivce-awesome` results in `/serivce-awesome/good-tracer/stats`
+- `postResponseCleanup: (Boolean | Object)`: defaults to `true`. If set to anything, the feature is enabled. 
+    - `delay: Number`: defaults to `1000 ms`. The amount of time to wait after reponse to delete a key from the cache.
 - `axios`: Configured axios instances provided to each request
     - `[key: string]: (Boolean | Object)`: if given, defaults to `{}`. Pass in any valid `axios` config options.
 - `cache`: internal memory cache settings. See [node-cache](https://github.com/node-cache/node-cache)

--- a/lib/index.js
+++ b/lib/index.js
@@ -89,12 +89,18 @@ internals.GoodTracerStream = class GoodSourceTracer extends Stream.Transform {
 
 internals.goodTracerStreamFactory = (server, options) => new internals.GoodTracerStream(server, options);
 
+const deleteKey = ({ cache, id }) => {
+    debug('deleting id: %s', id);
+    cache.del(id);
+};
+
 internals.delayCacheDeleteFactory = (delay) => (request) => {
     const requestId = get(request, 'info.id', 'NOOP');
     const scopedCache = get(request, ['server', 'plugins', NAME, 'cache']);
 
     // clean up cache
-    setTimeout(scopedCache.del, delay, requestId);
+    debug('delay delete of id %s for %d', requestId, delay);
+    setTimeout(deleteKey, delay, { cache: scopedCache, id: requestId });
 };
 
 exports.name = NAME;
@@ -199,12 +205,14 @@ exports.register = (server, options) => {
     });
 
     if (postResponseCleanup) {
+        debug('enabling post response cleanup');
         server.events.on('response', internals.delayCacheDeleteFactory(get(postResponseCleanup, 'delay', 1000)));
     }
     // End Trace Setup
 
     // Add stats route to view cache metrics
     if (enableStatsRoute) {
+        debug('enabling stats route: %s', `${baseRoute}/good-tracer/stats`);
         server.route({
             method: 'GET',
             path: `${baseRoute}/good-tracer/stats`,

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,7 @@ const DEFAULTS = {
         extendTTLOnGet: true, // extend TTL on cache get
         useClones: false
     },
+    postResponseCleanup: {}, // You can pass a `delay`, will default to 1000
     axios: {} // You can pass any axios configuration here
 };
 
@@ -88,6 +89,14 @@ internals.GoodTracerStream = class GoodSourceTracer extends Stream.Transform {
 
 internals.goodTracerStreamFactory = (server, options) => new internals.GoodTracerStream(server, options);
 
+internals.delayCacheDeleteFactory = (delay) => (request) => {
+    const requestId = get(request, 'info.id', 'NOOP');
+    const scopedCache = get(request, ['server', 'plugins', NAME, 'cache']);
+
+    // clean up cache
+    setTimeout(scopedCache.del, delay, requestId);
+};
+
 exports.name = NAME;
 
 exports.register = (server, options) => {
@@ -102,7 +111,7 @@ exports.register = (server, options) => {
     server.expose('GoodTracerStream', internals.goodTracerStreamFactory(cache, internals.settings));
 
     const {
-        traceUUIDHeader, traceDepthHeader, enableStatsRoute, baseRoute, axios
+        traceUUIDHeader, traceDepthHeader, enableStatsRoute, baseRoute, axios, postResponseCleanup
     } = internals.settings;
 
     // Expose server level axiosConfig
@@ -120,10 +129,18 @@ exports.register = (server, options) => {
         // set tracer info in memory cache
         const requestId = get(request, 'info.id', 'NOOP');
         const scopedCache = get(request, ['server', 'plugins', NAME, 'cache']);
-        scopedCache.set(requestId, {
-            uuid: tracerUUID,
-            depth: get(request, ['plugins', NAME, traceDepthHeader])
-        });
+        try {
+            scopedCache.set(requestId, {
+                uuid: tracerUUID,
+                depth: get(request, ['plugins', NAME, traceDepthHeader])
+            });
+        } catch (e) {
+            request.log(['error', 'good-tracer', 'cache'], {
+                error: e.name,
+                message: e.message,
+                cacheStats: get(request, ['server', 'plugins', NAME, 'cache']).getStats()
+            });
+        }
 
         debug('Request Trace headers: %o', {
             [traceUUIDHeader]: get(request, ['plugins', NAME, traceUUIDHeader]),
@@ -180,6 +197,10 @@ exports.register = (server, options) => {
 
         return h.continue;
     });
+
+    if (postResponseCleanup) {
+        server.events.on('response', internals.delayCacheDeleteFactory(get(postResponseCleanup, 'delay', 1000)));
+    }
     // End Trace Setup
 
     // Add stats route to view cache metrics

--- a/spec/error.spec.js
+++ b/spec/error.spec.js
@@ -107,7 +107,6 @@ describe('cache max keys error', () => {
             return get(lp, 'tags[0]', null) === 'error';
         })[0];
         const errLog = JSON.parse(errLogStr);
-        // const errLog = JSON.parse(logLines[2]);
         expect(errLog.tags).toEqual(['error', 'good-tracer', 'cache']);
         expect(errLog.data).toEqual({
             error: 'ECACHEFULL',

--- a/spec/error.spec.js
+++ b/spec/error.spec.js
@@ -1,0 +1,140 @@
+const Stream = require('stream');
+const Hapi = require('@hapi/hapi');
+const Good = require('@hapi/good');
+const { get } = require('lodash');
+const plugin = require('../lib');
+
+function sleep(ms) {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
+describe('cache max keys error', () => {
+    let server;
+    let logLines = [];
+
+    beforeEach(async () => {
+        server = new Hapi.Server({
+            host: 'localhost',
+            port: 8085
+        });
+
+        const getWithLog = (request) => {
+            request.log(['test'], 'This is a test!');
+            return 'Success!';
+        };
+
+        server.route({
+            method: 'GET',
+            path: '/log',
+            handler: getWithLog
+        });
+
+        const getWithSleep = async () => {
+            await sleep(500);
+            return 'Success!';
+        };
+
+        server.route({
+            method: 'GET',
+            path: '/sleep',
+            handler: getWithSleep
+        });
+
+        await server.register({
+            plugin,
+            options: {
+                cache: {
+                    maxKeys: 1
+                }
+            }
+        });
+
+        const LogEvents = class extends Stream.Transform {
+            constructor() {
+                super({ objectMode: true });
+                logLines = [];
+                this.once('end', () => {
+                    this._finalized = true;
+                });
+            }
+
+            _transform(value, enc, next) { // eslint-disable-line class-methods-use-this
+                logLines.push(value);
+                next(null, value);
+            }
+        };
+
+        const logReporters = {
+            console: [
+                server.plugins.goodTracer.GoodTracerStream,
+                {
+                    module: '@hapi/good-squeeze',
+                    name: 'Squeeze',
+                    args: [{
+                        response: '*',
+                        log: '*',
+                        request: '*',
+                        error: '*',
+                        ops: '*'
+                    }]
+                }, {
+                    module: '@hapi/good-squeeze',
+                    name: 'SafeJson'
+                },
+                new LogEvents()
+            ]
+        };
+
+        await server.register({
+            plugin: Good,
+            options: {
+                reporters: logReporters,
+            }
+        });
+    });
+
+    it('should catch the error and log out stats', async () => {
+        await Promise.all([
+            server.inject('/sleep'),
+            server.inject('/log'),
+        ]);
+
+        // find the error
+        const errLogStr = logLines.filter((l) => {
+            const lp = JSON.parse(l);
+            return get(lp, 'tags[0]', null) === 'error';
+        })[0];
+        const errLog = JSON.parse(errLogStr);
+        // const errLog = JSON.parse(logLines[2]);
+        expect(errLog.tags).toEqual(['error', 'good-tracer', 'cache']);
+        expect(errLog.data).toEqual({
+            error: 'ECACHEFULL',
+            message: 'Cache max keys amount exceeded',
+            cacheStats: {
+                hits: expect.any(Number),
+                misses: 1,
+                keys: 1,
+                ksize: expect.any(Number),
+                vsize: expect.any(Number)
+            }
+        });
+
+        const stats = logLines.reduce((prev, line) => {
+            const parsed = JSON.parse(line);
+
+            prev[parsed.event] += 1;
+            if (parsed.event === 'request') {
+                prev[parsed.tags[0]] += 1;
+            }
+            return prev;
+        }, {
+            error: 0, response: 0, request: 0, ops: 0, test: 0
+        });
+
+        expect(stats).toEqual({
+            error: 1, response: 2, request: 2, ops: 0, test: 1
+        });
+    });
+});

--- a/spec/transform.spec.js
+++ b/spec/transform.spec.js
@@ -92,10 +92,6 @@ describe('good-tracer log reporter stream', () => {
                 reporters: logReporters,
                 ops: {
                     interval: 900
-                },
-                includes: {
-                    request: ['headers'],
-                    response: ['headers']
                 }
             }
         });


### PR DESCRIPTION
- Silence and log cache set errors to avoid nuking a requests
- Added cache cleanup for after response action
- Added more debug logging

Added support for a `postResponseCleanup` (defaulted to `true`) that will clean up the associated cache items for a given request on a delay (defaulted to `1000 ms`) after the `response` event. This ensures that the `good` log stream has the cache value available when logging.

![delayed-delete](https://user-images.githubusercontent.com/1429775/88331923-5b5a8680-ccf3-11ea-9e80-20da2e07cdd7.png)

