### PR TITLE
debt(cache): adjusted default settings. Fixed bug with ttl setting. Deprecated orphaned callback in favor of node-cache TTL expiry

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ await server.register({
         enableStatsRoute: true, // optional defaults to false
         baseRoute: '/debug', // optional defaults to ''
         cache: {
-            ttl: 60 // optional defaults to 120 seconds
+            stdTTL: 60 // optional defaults to 3600 seconds
         },
         axios: {
             main: { // defaults to {}
@@ -162,13 +162,13 @@ See [node-cache](https://github.com/node-cache/node-cache) for available setting
 - `baseRoute`: defaults to `''`. Prepends to the `/good-tracer/stats` route.
     - Example: `baseRoute = /serivce-awesome` results in `/serivce-awesome/good-tracer/stats`
 - `postResponseCleanup: (Boolean | Object)`: defaults to `true`. If set to anything, the feature is enabled. 
-    - `delay: Number`: defaults to `1000 ms`. The amount of time to wait after reponse to delete a key from the cache.
+    - `delay: Number`: defaults to `1` second. The amount of time to wait after reponse to delete a key from the cache. You can pass decimal values for sub-second times.
 - `axios`: Configured axios instances provided to each request
     - `[key: string]: (Boolean | Object)`: if given, defaults to `{}`. Pass in any valid `axios` config options.
-- `cache`: internal memory cache settings. See [node-cache](https://github.com/node-cache/node-cache)
-    - `ttl`: default 120 seconds
-    - `checkPeriod`: default 5 minutes
-    - `maxKeys`: default `5000`
+- `cache`: internal memory cache settings. See [node-cache configuration](https://github.com/node-cache/node-cache#options)
+    - `stdTTL`: default `3600` seconds (1 hour)
+    - `checkperiod`: default `60` seconds
+    - `maxKeys`: default `-1` (no limit)
     - `useClones`: default `false`
     - `extendTTLOnGet`: This feature will reset the TTL to the global TTL when a successful `get` occurs. This will extend the life of an item in the cache as a result. default `true`
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,8 @@ const {
 } = require('lodash');
 const { factory } = require('./axios');
 
+const cacheDebug = debug.extend('cache');
+
 const NAME = 'goodTracer';
 
 const DEFAULTS = {
@@ -15,14 +17,14 @@ const DEFAULTS = {
     traceDepthHeader: 'x-gg-trace-depth',
     baseRoute: '',
     enableStatsRoute: false,
-    cache: {
-        ttl: 2 * 60, // 2 minutes
-        checkPeriod: 5 * 60, // 5 minutes
-        maxKeys: 5000,
+    cache: { // Any node-cache config option. See: https://github.com/node-cache/node-cache#options
+        stdTTL: 60 * 60, // 1 hour
+        checkperiod: 60, // 1 minute
+        maxKeys: -1,
         extendTTLOnGet: true, // extend TTL on cache get
         useClones: false
     },
-    postResponseCleanup: {}, // You can pass a `delay`, will default to 1000
+    postResponseCleanup: {}, // You can pass a `delay`, will default to 1 second
     axios: {} // You can pass any axios configuration here
 };
 
@@ -62,7 +64,7 @@ internals.GoodTracerStream = class GoodSourceTracer extends Stream.Transform {
     }
 
     injectTracerObject(data) {
-        debug('event type: %s', data.event);
+        debug('log event type: %s', data.event);
 
         // If we have a request, we can look for tracer info
         const requestID = get(data, 'id');
@@ -78,6 +80,7 @@ internals.GoodTracerStream = class GoodSourceTracer extends Stream.Transform {
                 set(data, 'tracer', value);
                 if (this._settings.cache.extendTTLOnGet) {
                     // Reset TTL on cached value
+                    cacheDebug('reset ttl for %s', requestID);
                     this._cache.ttl(requestID);
                 }
             }
@@ -89,20 +92,6 @@ internals.GoodTracerStream = class GoodSourceTracer extends Stream.Transform {
 
 internals.goodTracerStreamFactory = (server, options) => new internals.GoodTracerStream(server, options);
 
-const deleteKey = ({ cache, id }) => {
-    debug('deleting id: %s', id);
-    cache.del(id);
-};
-
-internals.delayCacheDeleteFactory = (delay) => (request) => {
-    const requestId = get(request, 'info.id', 'NOOP');
-    const scopedCache = get(request, ['server', 'plugins', NAME, 'cache']);
-
-    // clean up cache
-    debug('delay delete of id %s for %d', requestId, delay);
-    setTimeout(deleteKey, delay, { cache: scopedCache, id: requestId });
-};
-
 exports.name = NAME;
 
 exports.register = (server, options) => {
@@ -110,7 +99,21 @@ exports.register = (server, options) => {
     debug('Initialized with settings: %o', internals.settings);
 
     // Establish cache
+    cacheDebug('establishing cache with settings: %o', internals.settings.cache);
     const cache = new NodeCache(internals.settings.cache);
+
+    cache.on('set', (key, value) => {
+        cacheDebug('event: [SET] key: %s value: %o', key, value);
+    });
+
+    cache.on('del', (key) => {
+        cacheDebug('event: [DEL] key: %s', key);
+    });
+
+    cache.on('expired', (key) => {
+        cacheDebug('event: [EXP] key: %s', key);
+    });
+
     server.expose('cache', cache);
 
     // Establish Good reporter stream
@@ -206,7 +209,17 @@ exports.register = (server, options) => {
 
     if (postResponseCleanup) {
         debug('enabling post response cleanup');
-        server.events.on('response', internals.delayCacheDeleteFactory(get(postResponseCleanup, 'delay', 1000)));
+        server.events.on('response', (request) => {
+            const requestId = get(request, 'info.id', 'NOOP');
+            const scopedCache = get(request, ['server', 'plugins', NAME, 'cache']);
+
+            // default delay is 1 second
+            const delay = get(postResponseCleanup, 'delay', 1);
+
+            // clean up cache
+            cacheDebug('set ttl for %s to %d sec', requestId, delay);
+            scopedCache.ttl(requestId, delay);
+        });
     }
     // End Trace Setup
 

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -167,12 +167,15 @@ describe('good-tracer plugin', () => {
     it('should automatically delete the cache key after response', async () => {
         await registerPlugin({
             enableStatsRoute: true,
-            postResponseCleanup: { delay: 150 }
+            cache: {
+                checkperiod: 0.1
+            },
+            postResponseCleanup: { delay: 0.5 }
         });
         await server.inject('/');
         let result = await server.inject('/good-tracer/stats');
         expect(result.result.keys).toEqual(2);
-        await sleep(200);
+        await sleep(1000);
         result = await server.inject('/good-tracer/stats');
         expect(result.result.keys).toEqual(1);
     });


### PR DESCRIPTION
These changes are made in favor of allowing the `postResponseCleanup` to set a short TTL in combination of a very long default TTL + a faster check period. This should allow long running API calls to reliably retrieve the cached data and we avoid running into key limits.

- Adjusted default settings.
    - `stdTTL` default is now `3600` seconds
    - `checkperiod` is now `60` seconds
    - `maxKeys` is now `-1` (no limit)
- Fixed bug with ttl setting. Was `ttl` when it should gave been `stdTTL`
- Fixed bug with check period. Was `checkPeriod` when it should have been `checkperiod`
- Deprecated orphaned callback in favor of node-cache TTL expiry
- Improved debug logging