### PR TITLE
feat(onPreAuth): move injection of axios to onPreAuth to allow for use with Auth strategies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -159,7 +159,7 @@ exports.register = (server, options) => {
         return h.continue;
     });
 
-    server.ext('onPreHandler', (request, h) => {
+    server.ext('onPreAuth', (request, h) => {
         const axiosConfigs = {
             ...(options.axios || {}),
             ...get(request, ['route', 'settings', 'plugins', NAME, 'axios'], {})


### PR DESCRIPTION
Please see the [Hapi Request Lifecycle](https://hapi.dev/api/?v=20.0.3#request-lifecycle) docs.

Originally, we were use the `onPreHandler` event to trigger the injection of the `axios` clients on the `request`. This didn't allow the Tracer features to be easily available on an Auth Strategy within Hapi. Moving to the `onPreAuth` will allow the traced `axios` client for outgoing requests.